### PR TITLE
🧑‍💻 chore: add docs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ CLAUDE.MD
 # package-lock.json  # If using npm and want reproducible builds
 # yarn.lock         # If using yarn
 # pnpm-lock.yaml    # If using pnpm
+
+# docs 
+docs/*
+docs/


### PR DESCRIPTION
## Summary
Add docs directory to gitignore to exclude documentation build artifacts from version control.

## Type of Change
- [x] Maintenance/Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Added `docs/*` and `docs/` patterns to `.gitignore`
- Prevents documentation build artifacts from being tracked in git
- Improves repository cleanliness by excluding generated documentation files

## Impact
- No functional changes to the application
- Cleaner git status by excluding documentation build artifacts
- Follows best practices for gitignore configuration

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No tests required for gitignore changes
- [x] Documentation not applicable for this change